### PR TITLE
Drop settings, update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[ ![Download](https://api.bintray.com/packages/omaralvarez/public-conan/xsimd%3Aomaralvarez/images/download.svg?version=7.4.1%3Apublic-conan) ](https://bintray.com/omaralvarez/public-conan/xsimd%3Aomaralvarez/7.4.1%3Apublic-conan/link)
+[ ![Download](https://api.bintray.com/packages/omaralvarez/public-conan/xsimd%3Aomaralvarez/images/download.svg?version=7.4.7%3Apublic-conan) ](https://bintray.com/omaralvarez/public-conan/xsimd%3Aomaralvarez/7.4.7%3Apublic-conan/link)
 
 # conan-xsimd
     
@@ -6,7 +6,7 @@
 
 ### Basic setup
 
-    $ conan install xsimd/7.4.1@omaralvarez/public-conan
+    $ conan install xsimd/7.4.7@omaralvarez/public-conan
 
 ### Package basic test
     $ conan create . username/bintray-repo
@@ -18,7 +18,7 @@
 * A sample from `conanfile.txt` in the root directory:
 ```
 [requires]
-xsimd/7.4.1@omaralvarez/public-conan
+xsimd/7.4.7@omaralvarez/public-conan
 ...
 
 [generators]

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,21 +3,19 @@ from conans import ConanFile, CMake, tools
 
 class XsimdConan(ConanFile):
     name = "xsimd"
-    version = "7.4.0"
+    version = "7.4.7"
     license = "BSD 3-Clause"
-    #author = "<Put your name here> <And your email here>"
     url = "https://github.com/omaralvarez/conan-xsimd"
     repo_url = "https://github.com/QuantStack/xsimd"
     description = "Modern, portable C++ wrappers for SIMD intrinsics and parallelized, optimized math implementations (SSE, AVX, NEON, AVX512)"
     topics = ("simd-intrinsics", "vectorization", "simd")
-    settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     exports_sources = "*.hpp"
     no_copy_source = True
 
     def source(self):
         self.run("git clone -b '%s' --single-branch --depth 1 %s" % (self.version, self.repo_url))
-    
+
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.configure(source_folder="xsimd")
@@ -30,6 +28,6 @@ class XsimdConan(ConanFile):
     def package(self):
         cmake = self._configure_cmake()
         cmake.install()
-    
+
     def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
Setting an OS, compiler, etc., only makes a header-only library harder
to use with conan. Header-only library doesn't need to be compiled, so
it works with any OS, compiler, etc.

Also, there's a newer version of xsimd available.